### PR TITLE
Refactor HttpClientExtensions into HttpService

### DIFF
--- a/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application.UnitTests/Services/HttpServiceTests.cs
+++ b/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application.UnitTests/Services/HttpServiceTests.cs
@@ -3,17 +3,17 @@ using Moq;
 using Moq.Protected;
 using Opss.PrimaryAuthorityRegister.Web.Application.Entities;
 using Opss.PrimaryAuthorityRegister.Web.Application.Exceptions;
-using Opss.PrimaryAuthorityRegister.Web.Application.Extensions;
 using Opss.PrimaryAuthorityRegister.Common.Requests.Test.Commands;
 using System.Net;
 using System.Text.Json;
 using Opss.PrimaryAuthorityRegister.Common.Requests.Test.Queries;
 using Opss.PrimaryAuthorityRegister.Common.Requests.Test.Queries.Dtos;
 using Opss.PrimaryAuthorityRegister.Common;
+using Opss.PrimaryAuthorityRegister.Web.Application.Services;
 
-namespace Opss.PrimaryAuthorityRegister.Web.Application.UnitTests.Extensions;
+namespace Opss.PrimaryAuthorityRegister.Web.Application.UnitTests.Services;
 
-public class HttpClientExtensionsTests
+public class HttpServiceTests
 {
     private static string _baseAddress = "http://api/";
 
@@ -50,10 +50,12 @@ public class HttpClientExtensionsTests
             BaseAddress = new Uri(_baseAddress)
         };
 
+        var httpService = new HttpService(client);
+
         var query = new GetTestDataQuery(Guid.NewGuid());
 
         // Act
-        var response = await client.GetAsync<GetTestDataQuery, TestDataDto>(query).ConfigureAwait(true);
+        var response = await httpService.GetAsync<GetTestDataQuery, TestDataDto>(query).ConfigureAwait(true);
 
         // Assert
         var expectedUrl = $"{_baseAddress}api?name=GetTestDataQuery";
@@ -96,10 +98,12 @@ public class HttpClientExtensionsTests
             BaseAddress = new Uri("http://api/")
         };
 
+        var httpService = new HttpService(client);
+
         var query = new GetTestDataQuery(Guid.NewGuid());
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => client.GetAsync<GetTestDataQuery, TestDataDto>(query)).ConfigureAwait(true);
+        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => httpService.GetAsync<GetTestDataQuery, TestDataDto>(query)).ConfigureAwait(true);
         Assert.Contains("Unknown error occurred", exception.Message, StringComparison.InvariantCulture);
     }
 
@@ -136,11 +140,13 @@ public class HttpClientExtensionsTests
             BaseAddress = new Uri("http://api/")
         };
 
+        var httpService = new HttpService(client);
+
         var ownerId = Guid.NewGuid();
         var command = new CreateTestDataCommand(ownerId, "Something");
 
         // Act
-        var response = await client.PostAsync(command).ConfigureAwait(true);
+        var response = await httpService.PostAsync(command).ConfigureAwait(true);
 
         // Assert
         var expectedUrl = $"{_baseAddress}api?name=CreateTestDataCommand";
@@ -183,11 +189,13 @@ public class HttpClientExtensionsTests
             BaseAddress = new Uri("http://api/")
         };
 
+        var httpService = new HttpService(client);
+
         var ownerId = Guid.NewGuid();
         var command = new CreateTestDataCommand(ownerId, "Something");
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => client.PostAsync(command)).ConfigureAwait(true);
+        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => httpService.PostAsync(command)).ConfigureAwait(true);
         Assert.Contains("Unknown error occurred", exception.Message, StringComparison.InvariantCulture);
     }
 
@@ -223,12 +231,14 @@ public class HttpClientExtensionsTests
         {
             BaseAddress = new Uri("http://api/")
         };
-        
+
+        var httpService = new HttpService(client);
+
         var ownerId = Guid.NewGuid();
         var command = new UpdateTestDataCommand(ownerId, Guid.NewGuid(), "Something");
 
         // Act
-        var response = await client.PutAsync(command).ConfigureAwait(true);
+        var response = await httpService.PutAsync(command).ConfigureAwait(true);
 
         // Assert
         var expectedUrl = $"{_baseAddress}api?name=UpdateTestDataCommand";
@@ -271,11 +281,13 @@ public class HttpClientExtensionsTests
             BaseAddress = new Uri("http://api/")
         };
 
+        var httpService = new HttpService(client);
+
         var ownerId = Guid.NewGuid();
         var command = new UpdateTestDataCommand(ownerId, Guid.NewGuid(), "Something");
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => client.PutAsync(command)).ConfigureAwait(true);
+        var exception = await Assert.ThrowsAsync<HttpResponseException>(() => httpService.PutAsync(command)).ConfigureAwait(true);
         Assert.Contains("Unknown error occurred", exception.Message, StringComparison.InvariantCulture);
     }
 }

--- a/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application/Services/HttpService.cs
+++ b/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application/Services/HttpService.cs
@@ -1,15 +1,22 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Opss.PrimaryAuthorityRegister.Common;
+using Opss.PrimaryAuthorityRegister.Common.RequestInterfaces;
 using Opss.PrimaryAuthorityRegister.Web.Application.Entities;
 using Opss.PrimaryAuthorityRegister.Web.Application.Factories;
 using System.Text;
 using System.Text.Json;
-using Opss.PrimaryAuthorityRegister.Common.RequestInterfaces;
-using Opss.PrimaryAuthorityRegister.Common;
 
-namespace Opss.PrimaryAuthorityRegister.Web.Application.Extensions;
+namespace Opss.PrimaryAuthorityRegister.Web.Application.Services;
 
-public static class HttpClientExtensions
+public class HttpService : IHttpService
 {
+    private readonly HttpClient _httpClient;
+
+    public HttpService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
     /// <summary>
     /// Used to retrieve data
     /// </summary>
@@ -18,8 +25,9 @@ public static class HttpClientExtensions
     /// <param name="client">The HTTP Client</param>
     /// <param name="uri">Uri of the API endpoint</param>
     /// <returns></returns>
-    public static async Task<HttpObjectResponse<TResponse>> GetAsync<TQuery, TResponse>(this HttpClient client, TQuery query)
-        where TQuery : IQuery<TResponse> where TResponse : class => await HttpSendAsync<TQuery, TResponse>(client, HttpMethod.Get, query).ConfigureAwait(false);
+    public async Task<HttpObjectResponse<TResponse>> GetAsync<TQuery, TResponse>(TQuery query)
+        where TQuery : IQuery<TResponse>
+        where TResponse : class => await HttpSendAsync<TQuery, TResponse>(HttpMethod.Get, query).ConfigureAwait(false);
 
     /// <summary>
     /// Used when a command will return a Guid
@@ -29,8 +37,8 @@ public static class HttpClientExtensions
     /// <param name="uri">Uri of the API endpoint</param>
     /// <param name="command">The command to execute</param>
     /// <returns></returns>
-    public static async Task<HttpObjectResponse<CreatedResponse>> PostAsync<TCommand>(this HttpClient client, TCommand command)
-        where TCommand : ICommand<Guid> => await HttpSendAsync<TCommand, CreatedResponse>(client, HttpMethod.Post, command).ConfigureAwait(false);
+    public async Task<HttpObjectResponse<CreatedResponse>> PostAsync<TCommand>(TCommand command)
+        where TCommand : ICommand<Guid> => await HttpSendAsync<TCommand, CreatedResponse>(HttpMethod.Post, command).ConfigureAwait(false);
 
     /// <summary>
     /// Used to execute a command that doesn't create anything (i.e. no Id to be returned)
@@ -40,13 +48,12 @@ public static class HttpClientExtensions
     /// <param name="uri">Uri of the API endpoint</param>
     /// <param name="command">The command to execute</param>
     /// <returns></returns>
-    public static async Task<HttpObjectResponse<NoContentResult>> PutAsync<TCommand>(this HttpClient client, TCommand command)
-        where TCommand : ICommand => await HttpSendAsync<TCommand, NoContentResult>(client, HttpMethod.Put, command).ConfigureAwait(false);
+    public async Task<HttpObjectResponse<NoContentResult>> PutAsync<TCommand>(TCommand command) 
+        where TCommand : ICommand => await HttpSendAsync<TCommand, NoContentResult>(HttpMethod.Put, command).ConfigureAwait(false);
 
-    private static async Task<HttpObjectResponse<TResponse>> HttpSendAsync<TRequest, TResponse>(this HttpClient client, HttpMethod method, object? data)
+    private async Task<HttpObjectResponse<TResponse>> HttpSendAsync<TRequest, TResponse>(HttpMethod method, object? data)
         where TResponse : class
     {
-        ArgumentNullException.ThrowIfNull(client);
         var name = typeof(TRequest).Name;
         using var request = new HttpRequestMessage(method, new Uri($"api?name={name}", UriKind.Relative));
 
@@ -55,7 +62,7 @@ public static class HttpClientExtensions
             request.Content = new StringContent(JsonSerializer.Serialize(data), Encoding.UTF8, "application/json");
         }
 
-        var response = await client.SendAsync(request).ConfigureAwait(false);
+        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
         var result = await HttpObjectResponseFactory.DetermineSuccess<TResponse>(response).ConfigureAwait(false);
 

--- a/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application/Services/IHttpService.cs
+++ b/Web/Core/Opss.PrimaryAuthorityRegister.Web.Application/Services/IHttpService.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Opss.PrimaryAuthorityRegister.Common.RequestInterfaces;
+using Opss.PrimaryAuthorityRegister.Common;
+using Opss.PrimaryAuthorityRegister.Web.Application.Entities;
+
+namespace Opss.PrimaryAuthorityRegister.Web.Application.Services;
+
+public interface IHttpService
+{
+    /// <summary>
+    /// Used to retrieve data
+    /// </summary>
+    /// <typeparam name="TQuery">The type of the query being executed</typeparam>
+    /// <typeparam name="TResponse">The type of data being retrieved</typeparam>
+    /// <param name="client">The HTTP Client</param>
+    /// <param name="uri">Uri of the API endpoint</param>
+    /// <returns></returns>
+    public Task<HttpObjectResponse<TResponse>> GetAsync<TQuery, TResponse>(TQuery query)
+        where TQuery : IQuery<TResponse> where TResponse : class;
+
+    /// <summary>
+    /// Used when a command will return a Guid
+    /// </summary>
+    /// <typeparam name="TCommand">The type of the command being executed</typeparam>
+    /// <param name="client">The HTTP Cient</param>
+    /// <param name="uri">Uri of the API endpoint</param>
+    /// <param name="command">The command to execute</param>
+    /// <returns></returns>
+    public Task<HttpObjectResponse<CreatedResponse>> PostAsync<TCommand>(TCommand command)
+        where TCommand : ICommand<Guid>;
+
+    /// <summary>
+    /// Used to execute a command that doesn't create anything (i.e. no Id to be returned)
+    /// </summary>
+    /// <typeparam name="TCommand">The type of the command being executed</typeparam>
+    /// <param name="client">The HTTP Cient</param>
+    /// <param name="uri">Uri of the API endpoint</param>
+    /// <param name="command">The command to execute</param>
+    /// <returns></returns>
+    public Task<HttpObjectResponse<NoContentResult>> PutAsync<TCommand>(TCommand command)
+        where TCommand : ICommand;
+}

--- a/Web/Presentation/Opss.PrimaryAuthorityRegister.Web.UnitTests/AppTests.razor
+++ b/Web/Presentation/Opss.PrimaryAuthorityRegister.Web.UnitTests/AppTests.razor
@@ -8,7 +8,9 @@
     public void CultureCookie_IsSetOnInitialization()
     {
         // Arrange
+        var mockHttpService = new Mock<IHttpService>();
         var mockCookieService = new Mock<ICookieService>();
+        Services.AddSingleton(mockHttpService.Object);
         Services.AddSingleton(mockCookieService.Object);
         Services.AddLocalization(options => options.ResourcesPath = "LanguageResources");
 

--- a/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/Pages/Index.razor
+++ b/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/Pages/Index.razor
@@ -4,7 +4,7 @@
 @using Opss.PrimaryAuthorityRegister.Common.Requests.Test.Queries.Dtos
 @using Opss.PrimaryAuthorityRegister.Common.Requests.Test.Queries
 
-@inject HttpClient _httpClient
+@inject IHttpService _httpClient
 @inject IStringLocalizer<Index> Loc
 
 <PageTitle>@Loc["PageTitle"]</PageTitle>

--- a/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/Program.cs
+++ b/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/Program.cs
@@ -29,6 +29,7 @@ internal static class Program
         });
 
         builder.Services.AddScoped<ICookieService, CookieService>();
+        builder.Services.AddScoped<IHttpService, HttpService>();
         builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
         var app = builder.Build();

--- a/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/_Imports.razor
+++ b/Web/Presentation/Opss.PrimaryAuthorityRegister.Web/_Imports.razor
@@ -16,4 +16,4 @@
 @using Opss.DesignSystem.Frontend.Blazor.Components.Enums
 @using Opss.DesignSystem.Frontend.Blazor.Components.Shared
 
-@using Opss.PrimaryAuthorityRegister.Web.Application.Extensions
+@using Opss.PrimaryAuthorityRegister.Web.Application.Services


### PR DESCRIPTION
Testing Blazor components with Extension methods was proving difficult, this has been refactored out into a HttpService instead.